### PR TITLE
删除镜像中Redis和MySQL部分

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN mkdir -p /opt/ && \
     rm -f /opt/Python-3.6.1.tar.xz && rm -rf /opt/Python-3.6.1
 
 # python依赖
-RUN python3 -m venv py3 && \
+RUN cd /opt/ && \
+    python3 -m venv py3 && \
     source /opt/py3/bin/activate && \
     pip3 install --upgrade pip && \
     pip3 install -r /opt/jumpserver/requirements/requirements.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 RUN yum -y install epel-release && \
-    yum -y install gcc wget unzip nginx supervisor
+    yum -y install gcc wget unzip nginx supervisor && \
     yum clean all
 
 # 官方程序

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+RUN yum -y install epel-release && \
+    yum -y install gcc wget unzip nginx supervisor
+    yum clean all
+
 # 官方程序
 RUN wget https://github.com/jumpserver/jumpserver/archive/master.zip -O /opt/jumpserver.zip && \
     wget https://github.com/jumpserver/coco/archive/master.zip -O /opt/coco.zip && \
@@ -11,9 +15,7 @@ RUN wget https://github.com/jumpserver/jumpserver/archive/master.zip -O /opt/jum
     rm -f /opt/coco.zip /opt/jumpserver.zip /opt/luna.tar.gz
 
 # 基础依赖
-RUN yum -y install epel-release && \
-    yum -y install gcc wget unzip nginx supervisor && \
-    yum -y install $(cat /opt/jumpserver/requirements/rpm_requirements.txt) && \
+RUN yum -y install $(cat /opt/jumpserver/requirements/rpm_requirements.txt) && \
     yum -y install $(cat /opt/coco/requirements/rpm_requirements.txt) && \
     yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,39 @@
 FROM centos:7
 
-# 1. 安装基本依赖
-RUN yum update -y && yum install epel-release -y && yum update -y && yum install wget unzip epel-release nginx sqlite-devel xz gcc automake zlib-devel openssl-devel redis mariadb mariadb-devel mariadb-server supervisor -y
-WORKDIR /opt/
+# 官方程序
+RUN wget https://github.com/jumpserver/jumpserver/archive/master.zip -O /opt/jumpserver.zip && \
+    wget https://github.com/jumpserver/coco/archive/master.zip -O /opt/coco.zip && \
+    wget https://github.com/jumpserver/luna/releases/download/v1.0.0/luna.tar.gz -O /opt/luna.tar.gz && \
+    cd /opt/ && \
+    unzip coco.zip && mv coco{-master,} && \
+    unzip jumpserver.zip && mv jumpserver{-master,} && \
+    tar xzf luna.tar.gz && \
+    rm -f /opt/coco.zip /opt/jumpserver.zip /opt/luna.tar.gz
 
-# 2. 准备python
-RUN wget https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz -O /opt/Python-3.6.1.tar.xz
-RUN tar xf Python-3.6.1.tar.xz  && cd Python-3.6.1 && ./configure && make && make install
-RUN python3 -m venv py3
+# 基础依赖
+RUN yum -y install epel-release && \
+    yum -y install gcc wget unzip nginx supervisor && \
+    yum -y install $(cat /opt/jumpserver/requirements/rpm_requirements.txt) && \
+    yum -y install $(cat /opt/coco/requirements/rpm_requirements.txt) && \
+    yum clean all
 
-# 3. 下载包并解压
-RUN wget https://github.com/jumpserver/jumpserver/archive/master.zip -O /opt/jumpserver.zip
-RUN wget https://github.com/jumpserver/coco/archive/master.zip -O /opt/coco.zip
-RUN wget https://github.com/jumpserver/luna/releases/download/v1.0.0/luna.tar.gz -O /opt/luna.tar.gz
-RUN unzip coco.zip && mv coco-master coco && unzip jumpserver.zip && mv jumpserver-master jumpserver && tar xzf luna.tar.gz
+# 准备python
+RUN mkdir -p /opt/ && \
+    wget https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz -O /opt/Python-3.6.1.tar.xz && \
+    cd /opt/ && tar xf Python-3.6.1.tar.xz && cd ./Python-3.6.1 && \
+    ./configure && \
+    make && make install && \
+    cd /opt/ && \
+    rm -f /opt/Python-3.6.1.tar.xz && rm -rf /opt/Python-3.6.1
 
-# 4. 安装yum依赖
-RUN yum -y install $(cat /opt/jumpserver/requirements/rpm_requirements.txt) && yum -y install $(cat /opt/coco/requirements/rpm_requirements.txt)
+# python依赖
+RUN python3 -m venv py3 && \
+    source /opt/py3/bin/activate && \
+    pip3 install --upgrade pip && \
+    pip3 install -r /opt/jumpserver/requirements/requirements.txt && \
+    pip3 install -r /opt/coco/requirements/requirements.txt
 
-# 5. 安装pip依赖
-RUN source /opt/py3/bin/activate && pip install --upgrade pip && pip install -r /opt/jumpserver/requirements/requirements.txt &&  pip install -r /opt/coco/requirements/requirements.txt
-
-VOLUME /opt/coco/keys
-VOLUME /opt/jumpserver/data
-
-# 7. 准备文件
+# 准备文件
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervisord.conf /etc/supervisord.conf
 COPY jumpserver_conf.py /opt/jumpserver/config.py
@@ -32,7 +41,8 @@ COPY coco_conf.py /opt/coco/conf.py
 COPY entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh
 
-ENV REDIS_HOST=127.0.0.1 REDIS_PORT=6379
+VOLUME /opt/coco/keys /opt/jumpserver/data
 
 EXPOSE 2222 80
+
 ENTRYPOINT ["entrypoint.sh"]


### PR DESCRIPTION
Redis 和 MySQL 属于外部依赖，最好采用另外的镜像进行部署，不建议集成到一个镜像中。
但是 JumpServer 是一个项目，各组件依赖太大，不太适合拆分可以放到一个镜像中（Docker官方虽然不建议一个镜像跑多个进程，但是Docker官方的PHP镜像中也是有集成httpd的）